### PR TITLE
[WIP] feat: 99% of steps (waiting for perplexity API to work)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 node_modules/
 package-lock.json
 package.json
+
+
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ docker-push-code-interpreter-amd64: ## Push the Docker image for the code interp
 	docker tag code-interpreter-amd64:latest louis030195/assistants-code-interpreter:latest
 	docker push louis030195/assistants-code-interpreter:latest
 
+clean/rust: 
+	cargo clean
+
 clean/js:
 	rm -rf node_modules package-lock.json package.json
 

--- a/assistants-api-communication/src/lib.rs
+++ b/assistants-api-communication/src/lib.rs
@@ -7,5 +7,6 @@ pub mod executor;
 pub mod files;
 pub mod messages;
 pub mod models;
+pub mod run_steps;
 pub mod runs;
 pub mod threads;

--- a/assistants-api-communication/src/main.rs
+++ b/assistants-api-communication/src/main.rs
@@ -168,6 +168,14 @@ fn app(app_state: AppState) -> Router {
             delete(delete_run_handler),
         )
         .route("/threads/:thread_id/runs", get(list_runs_handler))
+        // GET https://api.openai.com/v1/threads/{thread_id}/runs/{run_id}/steps
+        // .route(
+        //     "/threads/:thread_id/runs/:run_id/steps",
+        //     get(list_run_steps_handler),
+        // )
+        // GET https://api.openai.com/v1/threads/{thread_id}/runs/{run_id}/steps/{step_id}
+        // .route("/threads/:thread_id/runs/:run_id/steps/:step_id", get(get_run_step_handler))
+
         .route(
             "/threads/:thread_id/runs/:run_id/submit_tool_outputs",
             post(submit_tool_outputs_handler),

--- a/assistants-api-communication/src/main.rs
+++ b/assistants-api-communication/src/main.rs
@@ -9,6 +9,7 @@ use assistants_api_communication::messages::{
     update_message_handler,
 };
 use assistants_api_communication::models::AppState;
+use assistants_api_communication::run_steps::{get_step_handler, list_steps_handler};
 use assistants_api_communication::runs::{
     create_run_handler, delete_run_handler, get_run_handler, list_runs_handler,
     submit_tool_outputs_handler, update_run_handler,
@@ -169,13 +170,15 @@ fn app(app_state: AppState) -> Router {
         )
         .route("/threads/:thread_id/runs", get(list_runs_handler))
         // GET https://api.openai.com/v1/threads/{thread_id}/runs/{run_id}/steps
-        // .route(
-        //     "/threads/:thread_id/runs/:run_id/steps",
-        //     get(list_run_steps_handler),
-        // )
+        .route(
+            "/threads/:thread_id/runs/:run_id/steps",
+            get(list_steps_handler),
+        )
         // GET https://api.openai.com/v1/threads/{thread_id}/runs/{run_id}/steps/{step_id}
-        // .route("/threads/:thread_id/runs/:run_id/steps/:step_id", get(get_run_step_handler))
-
+        .route(
+            "/threads/:thread_id/runs/:run_id/steps/:step_id",
+            get(get_step_handler),
+        )
         .route(
             "/threads/:thread_id/runs/:run_id/submit_tool_outputs",
             post(submit_tool_outputs_handler),

--- a/assistants-api-communication/src/run_steps.rs
+++ b/assistants-api-communication/src/run_steps.rs
@@ -1,0 +1,448 @@
+use assistants_api_communication::models::AppState;
+use assistants_core::models::RunStep;
+use assistants_core::run_steps::{create_step, get_step, list_steps, update_step};
+use async_openai::types::RunStepObject;
+use axum::{
+    extract::{Extension, Json, Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    response::Json as JsonResponse,
+};
+
+use log::error;
+use serde::{Deserialize, Serialize};
+use sqlx::types::Uuid;
+
+pub async fn get_step_handler(
+    Path((run_id, step_id)): Path<(String, String)>,
+    State(app_state): State<AppState>,
+) -> Result<JsonResponse<RunStepObject>, (StatusCode, String)> {
+    let user_id = Uuid::default().to_string();
+    let step = get_step(&app_state.pool, &step_id, &user_id).await;
+    match step {
+        Ok(step) => Ok(JsonResponse(step.inner)),
+        Err(e) => {
+            error!("Error getting step: {}", e);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        }
+    }
+}
+
+pub async fn list_steps_handler(
+    Path((run_id,)): Path<(String,)>,
+    State(app_state): State<AppState>,
+) -> Result<JsonResponse<Vec<RunStepObject>>, (StatusCode, String)> {
+    let user_id = Uuid::default().to_string();
+    let steps = list_steps(&app_state.pool, &run_id, &user_id).await;
+    match steps {
+        Ok(steps) => Ok(JsonResponse(steps.into_iter().map(|s| s.inner).collect())),
+        Err(e) => {
+            error!("Error listing steps: {}", e);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        assistants::{
+            create_assistant_handler, delete_assistant_handler, get_assistant_handler,
+            list_assistants_handler, update_assistant_handler,
+        },
+        messages::{
+            add_message_handler, delete_message_handler, get_message_handler,
+            list_messages_handler, update_message_handler,
+        },
+        models::AppState,
+        runs::{
+            create_run_handler, delete_run_handler, get_run_handler, list_runs_handler,
+            update_run_handler, ApiSubmittedToolCall, SubmitToolOutputsRequest,
+        },
+        threads::{
+            create_thread_handler, delete_thread_handler, get_thread_handler, list_threads_handler,
+            update_thread_handler,
+        },
+    };
+    use assistants_core::{executor::try_run_executor, file_storage::FileStorage};
+    use async_openai::types::{
+        AssistantObject, AssistantTools, AssistantToolsFunction, CreateAssistantRequest,
+        CreateRunRequest, FunctionObject, ListMessagesResponse, MessageContent, MessageRole,
+        RunObject, RunStatus, ThreadObject,
+    };
+    use axum::response::Response;
+    use axum::routing::{get, post};
+    use axum::Router;
+    use axum::{body::Body, routing::delete};
+    use axum::{
+        extract::DefaultBodyLimit,
+        http::{self, HeaderName, Request},
+    };
+    use dotenv::dotenv;
+    use hyper::{Method, StatusCode};
+    use serde_json::json;
+    use sqlx::{postgres::PgPoolOptions, PgPool};
+    use std::convert::Infallible;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tower::{Service, ServiceExt};
+    use tower_http::trace::TraceLayer;
+    use tower_http::{
+        cors::{Any, CorsLayer},
+        limit::RequestBodyLimitLayer,
+    };
+
+    async fn setup() -> AppState {
+        dotenv().ok();
+
+        let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .idle_timeout(Duration::from_secs(3))
+            .connect(&database_url)
+            .await
+            .expect("Failed to create pool.");
+        match env_logger::builder()
+            .filter_level(log::LevelFilter::Info)
+            .try_init()
+        {
+            Ok(_) => (),
+            Err(_) => (),
+        };
+        AppState {
+            pool: Arc::new(pool),
+            file_storage: Arc::new(FileStorage::new().await),
+            // Add other AppState fields here
+        }
+    }
+
+    fn app(app_state: AppState) -> Router {
+        let cors = CorsLayer::new()
+            .allow_methods([Method::GET, Method::POST])
+            .allow_origin(Any)
+            .allow_headers(vec![HeaderName::from_static("content-type")]);
+
+        Router::new()
+            .route(
+                "/threads/:thread_id/runs/:run_id/steps",
+                get(list_steps_handler),
+            )
+            .route(
+                "/threads/:thread_id/runs/:run_id/steps/:step_id",
+                get(get_step_handler),
+            )
+            .route("/assistants", post(create_assistant_handler))
+            .route("/assistants/:assistant_id", get(get_assistant_handler))
+            .route("/assistants/:assistant_id", post(update_assistant_handler))
+            .route(
+                "/assistants/:assistant_id",
+                delete(delete_assistant_handler),
+            )
+            .route("/assistants", get(list_assistants_handler))
+            .route("/threads", post(create_thread_handler))
+            .route("/threads/:thread_id", get(get_thread_handler))
+            .route("/threads", get(list_threads_handler))
+            .route("/threads/:thread_id", post(update_thread_handler))
+            .route("/threads/:thread_id", delete(delete_thread_handler))
+            .route("/threads/:thread_id/messages", post(add_message_handler))
+            .route(
+                "/threads/:thread_id/messages/:message_id",
+                get(get_message_handler),
+            )
+            .route(
+                "/threads/:thread_id/messages/:message_id",
+                post(update_message_handler),
+            )
+            .route(
+                "/threads/:thread_id/messages/:message_id",
+                delete(delete_message_handler),
+            )
+            .route("/threads/:thread_id/messages", get(list_messages_handler))
+            .route("/threads/:thread_id/runs", post(create_run_handler))
+            .route("/threads/:thread_id/runs/:run_id", get(get_run_handler))
+            .route("/threads/:thread_id/runs/:run_id", post(update_run_handler))
+            .route(
+                "/threads/:thread_id/runs/:run_id",
+                delete(delete_run_handler),
+            )
+            .route("/threads/:thread_id/runs", get(list_runs_handler))
+            .layer(DefaultBodyLimit::disable())
+            .layer(RequestBodyLimitLayer::new(250 * 1024 * 1024)) // 250mb
+            .layer(TraceLayer::new_for_http()) // Add this line
+            .layer(cors)
+            .with_state(app_state)
+    }
+
+    async fn reset_db(pool: &PgPool) {
+        sqlx::query!(
+            "TRUNCATE assistants, threads, messages, runs, functions, tool_calls, run_steps RESTART IDENTITY"
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_end_to_end_steps_with_parallel_functions() {
+        let app_state = setup().await;
+        let app = app(app_state.clone());
+        let pool_clone = app_state.pool.clone();
+
+        reset_db(&app_state.pool).await;
+
+        // Create an assistant with get_name and weather functions
+        let assistant = CreateAssistantRequest {
+            instructions: Some("Help me using functions.".to_string()),
+            name: Some("Parallel Functions Assistant".to_string()),
+            tools: Some(vec![
+                AssistantTools::Function(AssistantToolsFunction {
+                    r#type: "function".to_string(),
+                    function: FunctionObject {
+                        description: Some("A function that get my name.".to_string()),
+                        name: "get_name".to_string(),
+                        parameters: Some(json!({
+                            "type": "object",
+                            "properties": {}
+                        })),
+                    },
+                }),
+                AssistantTools::Function(AssistantToolsFunction {
+                    r#type: "function".to_string(),
+                    function: FunctionObject {
+                        description: Some("A function that get the weather.".to_string()),
+                        name: "get_weather".to_string(),
+                        parameters: Some(json!({
+                            "type": "object",
+                            "properties": {
+                                "city": {
+                                    "type": "string"
+                                }
+                            }
+                        })),
+                    },
+                }),
+            ]),
+            model: "mistralai/mixtral-8x7b-instruct".to_string(),
+            // model: "l/mistral-tiny".to_string(),
+            file_ids: None,
+            description: None,
+            metadata: None,
+        };
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri("/assistants")
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                    .body(Body::from(serde_json::to_vec(&assistant).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let assistant: AssistantObject = serde_json::from_slice(&body).unwrap();
+
+        // Create a thread
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri("/threads")
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let thread: ThreadObject = serde_json::from_slice(&body).unwrap();
+
+        // 4. Add a Message to a Thread
+        let message = json!({
+            "role": "user",
+            "content": "Please say my name and the current weather."
+        });
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri(format!("/threads/{}/messages", thread.id))
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                    .body(Body::from(message.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Create a run
+        let run_input = CreateRunRequest {
+            assistant_id: assistant.id,
+            instructions: Some("Please say my name and the current weather.".to_string()),
+            additional_instructions: None,
+            model: None,
+            tools: None,
+            metadata: None,
+        };
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri(format!("/threads/{}/runs", thread.id))
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                    .body(Body::from(serde_json::to_vec(&run_input).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let run: RunObject = serde_json::from_slice(&body).unwrap();
+
+        // Execute the run
+        let redis_url = std::env::var("REDIS_URL").expect("REDIS_URL must be set");
+        let client = redis::Client::open(redis_url).unwrap();
+        let mut con = client.get_async_connection().await.unwrap();
+        let result = try_run_executor(&pool_clone, &mut con).await;
+        assert!(result.is_ok(), "{:?}", result);
+
+        // Check the run status
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::GET)
+                    .uri(format!("/threads/{}/runs/{}", thread.id, run.id))
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let run: RunObject = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(run.status, RunStatus::RequiresAction);
+        let r_a = run.required_action;
+        // get the id of the weather tool call
+        let weather_call_id = r_a
+            .clone()
+            .unwrap()
+            .submit_tool_outputs
+            .tool_calls
+            .iter()
+            .find(|tool_call| tool_call.function.name == "get_weather")
+            .unwrap()
+            .id
+            .clone();
+
+        let name_call_id = r_a
+            .clone()
+            .unwrap()
+            .submit_tool_outputs
+            .tool_calls
+            .iter()
+            .find(|tool_call| tool_call.function.name == "get_name")
+            .unwrap()
+            .id
+            .clone();
+
+        // Submit tool outputs
+        let tool_outputs = vec![
+            ApiSubmittedToolCall {
+                tool_call_id: weather_call_id.clone(),
+                output: "20".to_string(), // Let's say the weather in New York is 20 Celsius
+            },
+            ApiSubmittedToolCall {
+                tool_call_id: name_call_id.clone(),
+                output: "Bob is my name".to_string(),
+            },
+        ];
+
+        let request = SubmitToolOutputsRequest { tool_outputs };
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::POST)
+                    .uri(format!(
+                        "/threads/{}/runs/{}/submit_tool_outputs",
+                        thread.id, run.id
+                    ))
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                    .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "{:?}",
+            hyper::body::to_bytes(response.into_body()).await.unwrap()
+        );
+
+        let redis_url = std::env::var("REDIS_URL").expect("REDIS_URL must be set");
+        let client = redis::Client::open(redis_url).unwrap();
+        let mut con = client.get_async_connection().await.unwrap();
+        let result = try_run_executor(&pool_clone, &mut con).await;
+
+        assert!(
+            result.is_ok(),
+            "The queue consumer should have run successfully. Instead, it returned: {:?}",
+            result
+        );
+        let run = result.unwrap();
+        assert_eq!(run.inner.status, RunStatus::Completed, "{:?}", run);
+
+        // Fetch the messages from the database
+        let response = app
+            .clone()
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::GET)
+                    .uri(format!("/threads/{}/messages", thread.id))
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let messages: ListMessagesResponse = serde_json::from_slice(&body).unwrap();
+
+        // Check
+        // Check the assistant's response
+        assert_eq!(messages.data.len(), 2);
+        assert_eq!(messages.data[1].role, MessageRole::Assistant);
+        if let MessageContent::Text(text_object) = &messages.data[1].content[0] {
+            assert!(
+                text_object.text.value.contains("20") 
+                || text_object.text.value.contains("Bob"), 
+                "Expected the assistant to return a text containing either '20' or 'Bob', but got something else: {}", 
+                text_object.text.value
+            );
+        } else {
+            panic!("Expected a Text message, but got something else.");
+        }
+    }
+}

--- a/assistants-api-communication/src/run_steps.rs
+++ b/assistants-api-communication/src/run_steps.rs
@@ -58,7 +58,8 @@ mod tests {
         models::AppState,
         runs::{
             create_run_handler, delete_run_handler, get_run_handler, list_runs_handler,
-            update_run_handler, ApiSubmittedToolCall, SubmitToolOutputsRequest,
+            submit_tool_outputs_handler, update_run_handler, ApiSubmittedToolCall,
+            SubmitToolOutputsRequest,
         },
         threads::{
             create_thread_handler, delete_thread_handler, get_thread_handler, list_threads_handler,
@@ -127,6 +128,10 @@ mod tests {
             .route(
                 "/threads/:thread_id/runs/:run_id/steps",
                 get(list_steps_handler),
+            )
+            .route(
+                "/threads/:thread_id/runs/:run_id/submit_tool_outputs",
+                post(submit_tool_outputs_handler),
             )
             .route(
                 "/threads/:thread_id/runs/:run_id/steps/:step_id",

--- a/assistants-core/Cargo.toml
+++ b/assistants-core/Cargo.toml
@@ -15,7 +15,7 @@ tokio-stream = "0.1"
 tower-http = { version = "0.4.0", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-sqlx = { version = "0.7.3", features = ["macros", "postgres", "runtime-async-std-rustls", "json", "uuid"] }
+sqlx = { version = "0.7.3", features = ["macros", "postgres", "runtime-async-std-rustls", "json", "uuid", "chrono"] }
 
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/assistants-core/src/code_interpreter.rs
+++ b/assistants-core/src/code_interpreter.rs
@@ -87,7 +87,7 @@ pub async fn safe_interpreter(
     attempt: usize,
     max_attempts: usize,
     model_config: InterpreterModelConfig,
-) -> Result<String, InterpreterError> {
+) -> Result<(String, String), InterpreterError> {
     if attempt >= max_attempts {
         return Err(InterpreterError {
             message: String::from("Max attempts reached"),
@@ -96,7 +96,7 @@ pub async fn safe_interpreter(
     }
 
     match interpreter(user_input.clone(), model_config.clone()).await {
-        Ok((result, _model_output)) => Ok(result),
+        Ok((code_output, code)) => Ok((code_output, code)),
         Err(e) => {
             eprintln!("Error: {}", e);
             let input = format!(
@@ -377,10 +377,10 @@ mod tests {
                 input,
                 result
             );
-            let result_string = result.unwrap();
+            let (code_output, code) = result.unwrap();
             println!(
                 "Problem to solve: {}. \nOutput: {}\nExpected output: {}",
-                input, result_string, expected_output
+                input, code_output, expected_output
             );
 
             let p = "You are an AI that checks the correctness of math results. 
@@ -399,7 +399,7 @@ Rules:
                 p,
                 &format!(
                     "User input: {}\nResult: {}. Official solution: {}. Is my result correct?",
-                    input, result_string, expected_output
+                    input, code_output, expected_output
                 ),
                 Some(0.0),
                 -1,

--- a/assistants-core/src/function_calling.rs
+++ b/assistants-core/src/function_calling.rs
@@ -106,6 +106,10 @@ Please provide the name of the function you want to use and the arguments in the
 Rules:
 - The function name must be one of the functions available.
 - The arguments must be a subset of the arguments available.
+- Generate a single function at a time!
+- Generate a single JSON object at a time or it will break!
+- Do not return your input as output! Just return the function call!
+- Do not escape characters!
 - The arguments must be in the correct format (e.g. string, integer, etc.).
 - The arguments must be required by the function (e.g. if the function requires a parameter called 'city', then you must provide a value for 'city').
 - The arguments must be valid (e.g. if the function requires a parameter called 'city', then you must provide a valid city name).
@@ -119,31 +123,31 @@ Examples:
 
 1. Fetching a user's profile
 
-Prompt:
+You receive:
 {\"function\": {\"description\": \"Fetch a user's profile\",\"name\": \"get_user_profile\",\"parameters\": {\"username\": {\"properties\": {},\"required\": [\"username\"],\"type\": \"string\"}}},\"user_context\": \"I want to see the profile of user 'john_doe'.\"}
-Answer:
+Your answer:
 { \"name\": \"get_user_profile\", \"arguments\": { \"username\": \"john_doe\" } }
 
 2. Sending a message
 
-Prompt:
+You receive:
 {\"function\": {\"description\": \"Send a message to a user\",\"name\": \"send_message\",\"parameters\": {\"recipient\": {\"properties\": {},\"required\": [\"recipient\"],\"type\": \"string\"}, \"message\": {\"properties\": {},\"required\": [\"message\"],\"type\": \"string\"}}},\"user_context\": \"I want to send 'Hello, how are you?' to 'jane_doe'.\"}
-Answer:
+Your answer:
 { \"name\": \"send_message\", \"arguments\": { \"recipient\": \"jane_doe\", \"message\": \"Hello, how are you?\" } }
 
 Negative examples:
 
-Prompt:
+You receive:
 {\"function\": {\"description\": \"Get the weather for a city\",\"name\": \"weather\",\"parameters\": {\"city\": {\"properties\": {},\"required\": [\"city\"],\"type\": \"string\"}}},\"user_context\": \"Give me a weather report for Toronto, Canada.\"}
-Incorrect Answer:
+Your Incorrect Answer:
 { \"name\": \"weather\", \"arguments\": { \"city\": \"Toronto, Canada\" } }
 
 In this case, the function weather expects a city parameter, but the llm provided a city and country (\"Toronto, Canada\") instead of just the city (\"Toronto\"). This would cause the function call to fail because the weather function does not know how to handle a city and country as input.
 
 
-Prompt:
+You receive:
 {\"function\": {\"description\": \"Send a message to a user\",\"name\": \"send_message\",\"parameters\": {\"recipient\": {\"properties\": {},\"required\": [\"recipient\"],\"type\": \"string\"}, \"message\": {\"properties\": {},\"required\": [\"message\"],\"type\": \"string\"}}},\"user_context\": \"I want to send 'Hello, how are you?' to 'jane_doe'.\"}
-Incorrect Answer:
+Your Incorrect Answer:
 {\"function\": {\"description\": \"Send a message to a user\",\"name\": \"send_message\",\"parameters\": {\"recipient\": {\"properties\": {},\"required\": [\"recipient\"],\"type\": \"string\"}, \"message\": {\"properties\": {},\"required\": [\"message\"],\"type\": \"string\"}}},\"user_context\": \"I want to send 'Hello, how are you?' to 'jane_doe'.\"}
 
 In this case, the LLM simply returned the exact same input as output, which is not a valid function call.

--- a/assistants-core/src/function_calling.rs
+++ b/assistants-core/src/function_calling.rs
@@ -152,7 +152,8 @@ Your Incorrect Answer:
 
 In this case, the LLM simply returned the exact same input as output, which is not a valid function call.
 
-Your answer will be used to call the function so it must be in JSON format, do not say anything but the function name and the parameters.";
+Your answer will be used to call the function so it must be in JSON format, do not say anything but the function name and the parameters.
+Function call:";
 
 #[derive(Debug)]
 pub enum FunctionCallError {

--- a/assistants-core/src/lib.rs
+++ b/assistants-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod openapi;
 pub mod pdf_utils;
 pub mod prompts;
 pub mod retrieval;
+pub mod run_steps;
 pub mod runs;
 pub mod test_data;
 pub mod threads;

--- a/assistants-core/src/migrations.sql
+++ b/assistants-core/src/migrations.sql
@@ -15,6 +15,7 @@ DROP TABLE IF EXISTS runs;
 DROP TABLE IF EXISTS functions;
 DROP TABLE IF EXISTS tool_calls;
 DROP TABLE IF EXISTS chunks;
+DROP TABLE IF EXISTS run_steps;
 
 -- Create assistants table
 CREATE TABLE assistants (
@@ -112,6 +113,27 @@ CREATE TABLE chunks (
     -- embedding VECTOR(8192), -- hardcoded atm https://huggingface.co/jinaai/jina-embeddings-v2-base-en
     created_at INTEGER NOT NULL DEFAULT (EXTRACT(EPOCH FROM NOW()))
 );
+
+CREATE TABLE run_steps (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    object TEXT,
+    created_at INTEGER NOT NULL DEFAULT (EXTRACT(EPOCH FROM NOW())),
+    run_id UUID REFERENCES runs(id),
+    assistant_id UUID REFERENCES assistants(id),
+    thread_id UUID REFERENCES threads(id),
+    type TEXT,
+    status TEXT,
+    cancelled_at INTEGER,
+    completed_at INTEGER,
+    expired_at INTEGER,
+    failed_at INTEGER,
+    last_error JSONB,
+    step_details JSONB,
+    usage JSONB,
+    metadata JSONB,
+    user_id UUID
+);
+-- TODO INDEXES
 -- CREATE INDEX ON chunks USING hnsw (embedding vector_l2_ops);
 -- CREATE INDEX ON chunks USING hnsw (embedding vector_ip_ops);
 -- CREATE INDEX ON chunks USING hnsw (embedding vector_cosine_ops);

--- a/assistants-core/src/models.rs
+++ b/assistants-core/src/models.rs
@@ -1,7 +1,8 @@
 use assistants_extra::anthropic;
 use async_openai::types::{
-    AssistantObject, ChatCompletionFunctions, FunctionObject, MessageObject, MessageRole,
-    RunObject, RunStatus, ThreadObject,
+    AssistantObject, ChatCompletionFunctions, FunctionObject, MessageCreation, MessageObject,
+    MessageRole, RunObject, RunStatus, RunStepDetailsMessageCreationObject, RunStepObject,
+    RunStepType, StepDetails, ThreadObject,
 };
 use redis::RedisError;
 use serde::{self, Deserialize, Serialize};
@@ -195,4 +196,40 @@ pub struct PartialChunk {
     pub data: String,
     pub start_index: i32,
     pub end_index: i32,
+}
+
+#[derive(Debug, sqlx::FromRow, Serialize, Deserialize)]
+pub struct RunStep {
+    pub inner: RunStepObject,
+    pub user_id: String,
+}
+
+impl Default for RunStep {
+    fn default() -> Self {
+        Self {
+            inner: RunStepObject {
+                id: Uuid::new_v4().to_string(),
+                object: String::new(),
+                created_at: 0,
+                assistant_id: Some(Uuid::new_v4().to_string()),
+                thread_id: Uuid::new_v4().to_string(),
+                run_id: Uuid::new_v4().to_string(),
+                r#type: RunStepType::MessageCreation,
+                status: RunStatus::Queued,
+                step_details: StepDetails::MessageCreation(RunStepDetailsMessageCreationObject {
+                    r#type: String::new(),
+                    message_creation: MessageCreation {
+                        message_id: Uuid::new_v4().to_string(),
+                    },
+                }),
+                last_error: None,
+                expired_at: Some(0),
+                cancelled_at: None,
+                failed_at: None,
+                completed_at: None,
+                metadata: None,
+            },
+            user_id: String::new(),
+        }
+    }
 }

--- a/assistants-core/src/run_steps.rs
+++ b/assistants-core/src/run_steps.rs
@@ -1,0 +1,299 @@
+use std::collections::HashMap;
+
+use crate::models::RunStep;
+use async_openai::types::{RunStatus, RunStepObject, RunStepType, StepDetails};
+use log::info;
+use sqlx::{types::Uuid, PgPool};
+
+pub async fn create_step(
+    pool: &PgPool,
+    run_id: &str,
+    assistant_id: &str,
+    thread_id: &str,
+    step_type: RunStepType,
+    status: RunStatus,
+    step_details: StepDetails,
+    user_id: &str,
+) -> Result<RunStep, sqlx::Error> {
+    info!("Creating step for run_id: {}", run_id);
+    let row = sqlx::query!(
+        r#"
+        INSERT INTO run_steps (run_id, assistant_id, thread_id, type, status, step_details, user_id)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        RETURNING *
+        "#,
+        Uuid::parse_str(run_id).unwrap(),
+        Uuid::parse_str(assistant_id).unwrap(),
+        Uuid::parse_str(thread_id).unwrap(),
+        match step_type {
+            RunStepType::MessageCreation => "message_creation",
+            RunStepType::ToolCalls => "tool_calls",
+        },
+        match status {
+            RunStatus::Queued => "queued",
+            RunStatus::InProgress => "in_progress",
+            RunStatus::RequiresAction => "requires_action",
+            RunStatus::Completed => "completed",
+            RunStatus::Failed => "failed",
+            RunStatus::Cancelled => "cancelled",
+            RunStatus::Expired => "expired",
+            RunStatus::Cancelling => "cancelling",
+        },
+        serde_json::to_value(step_details).unwrap(),
+        Uuid::parse_str(user_id).unwrap()
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(RunStep {
+        inner: RunStepObject {
+            id: row.id.to_string(),
+            object: row.object.unwrap_or_default(),
+            created_at: row.created_at,
+            assistant_id: Some(row.assistant_id.unwrap_or_default().to_string()),
+            thread_id: row.thread_id.unwrap_or_default().to_string(),
+            run_id: row.run_id.unwrap_or_default().to_string(),
+            r#type: if row.r#type.unwrap() == "message_creation" {
+                RunStepType::MessageCreation
+            } else {
+                RunStepType::ToolCalls
+            },
+            status: match row.status.unwrap_or_default().as_str() {
+                "queued" => RunStatus::Queued,
+                "in_progress" => RunStatus::InProgress,
+                "requires_action" => RunStatus::RequiresAction,
+                "completed" => RunStatus::Completed,
+                "failed" => RunStatus::Failed,
+                "cancelled" => RunStatus::Cancelled,
+                _ => RunStatus::Queued,
+            },
+            step_details: serde_json::from_value(row.step_details.unwrap_or_default()).unwrap(),
+            last_error: serde_json::from_value(row.last_error.unwrap_or_default())
+                .unwrap_or_default(),
+            expired_at: row.expired_at,
+            cancelled_at: row.cancelled_at,
+            failed_at: row.failed_at,
+            completed_at: row.completed_at,
+            metadata: Some(
+                serde_json::from_value::<HashMap<String, serde_json::Value>>(
+                    row.metadata.unwrap_or_default(),
+                )
+                .unwrap_or_default(),
+            ),
+        },
+        user_id: row.user_id.unwrap_or_default().to_string(),
+    })
+}
+
+pub async fn get_step(pool: &PgPool, step_id: &str, user_id: &str) -> Result<RunStep, sqlx::Error> {
+    info!("Getting step from database for step_id: {}", step_id);
+    let row = sqlx::query!(
+        r#"
+        SELECT * FROM run_steps WHERE id::text = $1 AND user_id::text = $2
+        "#,
+        step_id,
+        user_id,
+    )
+    .fetch_one(pool)
+    .await?;
+
+    // TODO: Map the returned row to a RunStep object and return it
+    Ok(RunStep {
+        inner: RunStepObject {
+            id: row.id.to_string(),
+            object: row.object.unwrap(),
+            created_at: row.created_at,
+            assistant_id: Some(row.assistant_id.unwrap_or_default().to_string()),
+            thread_id: row.thread_id.unwrap_or_default().to_string(),
+            run_id: row.run_id.unwrap_or_default().to_string(),
+            r#type: if row.r#type.unwrap() == "message_creation" {
+                RunStepType::MessageCreation
+            } else {
+                RunStepType::ToolCalls
+            },
+            status: match row.status.unwrap_or_default().as_str() {
+                "queued" => RunStatus::Queued,
+                "in_progress" => RunStatus::InProgress,
+                "requires_action" => RunStatus::RequiresAction,
+                "completed" => RunStatus::Completed,
+                "failed" => RunStatus::Failed,
+                "cancelled" => RunStatus::Cancelled,
+                _ => RunStatus::Queued,
+            },
+            step_details: serde_json::from_value(row.step_details.unwrap_or_default()).unwrap(),
+            last_error: serde_json::from_value(row.last_error.unwrap_or_default())
+                .unwrap_or_default(),
+            expired_at: row.expired_at,
+            cancelled_at: row.cancelled_at,
+            failed_at: row.failed_at,
+            completed_at: row.completed_at,
+            metadata: Some(
+                serde_json::from_value::<HashMap<String, serde_json::Value>>(
+                    row.metadata.unwrap_or_default(),
+                )
+                .unwrap_or_default(),
+            ),
+        },
+        user_id: row.user_id.unwrap_or_default().to_string(),
+    })
+}
+
+pub async fn list_steps(
+    pool: &PgPool,
+    run_id: &str,
+    user_id: &str,
+) -> Result<Vec<RunStep>, sqlx::Error> {
+    info!("Listing steps for run_id: {}", run_id);
+    let rows = sqlx::query!(
+        r#"
+        SELECT * FROM run_steps WHERE run_id::text = $1 AND user_id::text = $2
+        "#,
+        run_id,
+        user_id,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    // TODO: Map the returned rows to a vector of RunStep objects and return it
+    Ok(rows
+        .into_iter()
+        .map(|row| RunStep {
+            inner: RunStepObject {
+                id: row.id.to_string(),
+                object: row.object.unwrap_or_default(),
+                created_at: row.created_at,
+                assistant_id: Some(row.assistant_id.unwrap_or_default().to_string()),
+                thread_id: row.thread_id.unwrap_or_default().to_string(),
+                run_id: row.run_id.unwrap_or_default().to_string(),
+                r#type: if row.r#type.unwrap() == "message_creation" {
+                    RunStepType::MessageCreation
+                } else {
+                    RunStepType::ToolCalls
+                },
+                status: match row.status.unwrap_or_default().as_str() {
+                    "queued" => RunStatus::Queued,
+                    "in_progress" => RunStatus::InProgress,
+                    "requires_action" => RunStatus::RequiresAction,
+                    "completed" => RunStatus::Completed,
+                    "failed" => RunStatus::Failed,
+                    "cancelled" => RunStatus::Cancelled,
+                    _ => RunStatus::Queued,
+                },
+                step_details: serde_json::from_value(row.step_details.unwrap_or_default()).unwrap(),
+                last_error: serde_json::from_value(row.last_error.unwrap_or_default())
+                    .unwrap_or_default(),
+                expired_at: row.expired_at,
+                cancelled_at: row.cancelled_at,
+                failed_at: row.failed_at,
+                completed_at: row.completed_at,
+                metadata: Some(
+                    serde_json::from_value::<HashMap<String, serde_json::Value>>(
+                        row.metadata.unwrap_or_default(),
+                    )
+                    .unwrap_or_default(),
+                ),
+            },
+            user_id: row.user_id.unwrap_or_default().to_string(),
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        assistants::create_assistant, models::Assistant, runs::create_run, threads::create_thread,
+    };
+
+    use super::*;
+    use async_openai::types::{
+        AssistantObject, MessageCreation, RunStepDetailsMessageCreationObject,
+    };
+    use dotenv::dotenv;
+    use sqlx::postgres::PgPoolOptions;
+    use std::env;
+    use uuid::Uuid;
+
+    async fn setup() -> PgPool {
+        dotenv().ok();
+        let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await
+            .expect("Failed to create pool.");
+        pool
+    }
+
+    async fn reset_db(pool: &PgPool) {
+        sqlx::query!(
+            "TRUNCATE assistants, threads, messages, runs, functions, tool_calls, run_steps RESTART IDENTITY"
+            )
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_list_steps() {
+        let pool = setup().await;
+        reset_db(&pool).await;
+
+        let user_id = Uuid::new_v4();
+        let assistant = Assistant {
+            inner: AssistantObject {
+                id: "".to_string(),
+                instructions: Some("".to_string()),
+                name: Some("Math Tutor".to_string()),
+                tools: vec![],
+                model: "bob/john".to_string(),
+                file_ids: vec![],
+                object: "object_value".to_string(),
+                created_at: 0,
+                description: Some("description_value".to_string()),
+                metadata: None,
+            },
+            user_id: Uuid::default().to_string(),
+        };
+        let assistant = create_assistant(&pool, &assistant).await.unwrap();
+        // Insert a run into the database
+        let thread = create_thread(&pool, &user_id.to_string()).await.unwrap();
+        let run = create_run(
+            &pool,
+            &thread.inner.id,
+            &assistant.inner.id,
+            "No",
+            &user_id.to_string(),
+        )
+        .await
+        .unwrap();
+
+        // Insert a run_step into the database
+        create_step(
+            &pool,
+            &run.inner.id,
+            &assistant.inner.id,
+            &thread.inner.id,
+            RunStepType::MessageCreation,
+            RunStatus::Queued,
+            StepDetails::MessageCreation(RunStepDetailsMessageCreationObject {
+                r#type: "message_creation".to_string(),
+                message_creation: MessageCreation {
+                    message_id: "message_id".to_string(),
+                },
+            }),
+            &user_id.to_string(),
+        )
+        .await
+        .unwrap();
+
+        let result = list_steps(&pool, &run.inner.id.to_string(), &user_id.to_string())
+            .await
+            .unwrap();
+
+        // Assert that the result contains the inserted run_step
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].user_id, user_id.to_string());
+        assert_eq!(result[0].inner.run_id, run.inner.id.to_string());
+        assert_eq!(result[0].inner.status, RunStatus::Queued);
+    }
+}

--- a/assistants-core/src/runs.rs
+++ b/assistants-core/src/runs.rs
@@ -90,6 +90,7 @@ pub async fn submit_tool_outputs(
 
     // Iterate over tool_outputs and update each tool_call in the database
     for tool_output in tool_outputs {
+        info!("Updating tool call for tool_call_id: {}", tool_output.id);
         // TODO parallel
         sqlx::query!(
             r#"
@@ -495,6 +496,7 @@ pub async fn update_run_status(
     if let Some(action) = required_action {
         futures::stream::iter(action.submit_tool_outputs.tool_calls.iter())
             .then(|tool_call| async move {
+                info!("Creating tool call for tool_call_id: {}", tool_call.id);
                 let _ = sqlx::query!(
                     r#"
                     INSERT INTO tool_calls (id, run_id, user_id)

--- a/assistants-core/src/runs.rs
+++ b/assistants-core/src/runs.rs
@@ -734,7 +734,7 @@ mod tests {
     async fn reset_db(pool: &PgPool) {
         // TODO should also purge minio
         sqlx::query!(
-            "TRUNCATE assistants, threads, messages, runs, functions, tool_calls RESTART IDENTITY"
+            "TRUNCATE assistants, threads, messages, runs, functions, tool_calls, run_steps RESTART IDENTITY"
         )
         .execute(pool)
         .await


### PR DESCRIPTION
uncertainties:
- do you need to create a step when the assistant decide to use function calling and put in requires action the run?
- do you need to create step for each function calls sent by the user?
- do the assistant create multiple steps during code interpreter? (e.g. analysing bitcoin price takes a while maybe generating bunch of code adding bunch of steps etc.?)
- will implement some types for the action tool in async-openai
- atm code interpreter does not generate image (add issue)
- i know that chatgpt stream steps but i dont think assistants api does that (they did a hack prob)

## core

- [x] migrations
- [x] type
- [x] on assistant message
- [x] code interpreter input output
- [x] steps for actions
- [x] steps for functions
  - [x] function call server
  - [x] function call client output update in the step
  - [x] parallel function calling
- [x] update all steps to the right status after execution
- [x] >80% unit test use cases

## api 

- [x] list steps
- [x] get steps
- [x] retrieve step 
- [x] unit test all use cases



## nice to have but not gonna implement for now

- [ ] cancelled
- [ ] expired
- [ ] failed -> partiallly 
- [ ] ?
